### PR TITLE
Added the ability to define a custom base url after the files has been uploaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You need to add a new property called `aws` to your `config/custom.json` file(s)
   "aws": {
     "accessKeyId": "${process.env.AWS_ACCESS_KEY_ID || AWS Access Key Id}",
     "secretAccessKey": "${process.env.AWS_SECRET_ACCESS_KEY || AWS Secret Key}"
+    "customBaseUrl": "${process.env.CDN_BASE_URL || 'https://cdn.example.com/'}"
   }
 }
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,9 @@ module.exports = {
               }
 
               // set the bucket file url
-              file.url = data.Location;
+              strapi.config.aws.customBaseUrl? 
+                file.url = `${trimParam(strapi.config.aws.customBaseUrl)}${path}${file.hash}${file.ext}`:
+                file.url = data.Location;
 
               resolve();
             }


### PR DESCRIPTION
This can be useful if you are using s3 as your file storage but providing files using i.e. CloudFront with a custom domain. 

=> #1 